### PR TITLE
Changing ProtectYourPC from 3 to 1. MSFT reccommended settings.

### DIFF
--- a/Autounattend.xml
+++ b/Autounattend.xml
@@ -91,7 +91,7 @@
                 <Username>vagrant</Username>
             </AutoLogon>
             <OOBE>
-                <ProtectYourPC>3</ProtectYourPC>
+                <ProtectYourPC>1</ProtectYourPC>
             </OOBE>
             <FirstLogonCommands>
                 <SynchronousCommand wcm:action="add">


### PR DESCRIPTION
Meant to change `ProtectYourPC` from 3 to 1 a long time ago, but apparently I neglected to do so. Fixed. 

This will turn things like SmartScreen and whatnot on.
