### PR TITLE
Minor changes to the default Vagrantfile to conserve resources.

### DIFF
--- a/vagrantfile.template
+++ b/vagrantfile.template
@@ -4,24 +4,24 @@
 Vagrant.require_version ">= 1.6.2"
 
 Vagrant.configure("2") do |config|
-    config.vm.box = "windows_81"
+    config.vm.box = "windows_10"
     config.vm.communicator = "winrm"
 
     config.vm.guest = :windows
 
-    config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct: true
+    config.vm.network :forwarded_port, guest: 3389, host: 3399, id: "rdp", auto_correct: true
     config.vm.network :forwarded_port, guest: 5985, host: 5985, id: "winrm", auto_correct: true
 
     config.vm.provider "vmware_fusion" do |v, override|
         v.vmx["memsize"] = "2048"
-        v.vmx["numvcpus"] = "2"
+        v.vmx["numvcpus"] = "1"
         v.vmx["ethernet0.virtualDev"] = "vmxnet3"
         v.vmx["scsi0.virtualDev"] = "lsisas1068"
     end
 
     config.vm.provider "vmware_workstation" do |v, override|
         v.vmx["memsize"] = "2048"
-        v.vmx["numvcpus"] = "2"
+        v.vmx["numvcpus"] = "1"
         v.vmx["ethernet0.virtualDev"] = "vmxnet3"
         v.vmx["scsi0.virtualDev"] = "lsisas1068"
     end


### PR DESCRIPTION
Now the box defaults to a single CPU when provisioned.
