### PR TITLE
Added a license and fixed vagrant user password expiration

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Lucius Bono 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/no-expiration.ps1
+++ b/no-expiration.ps1
@@ -1,0 +1,1 @@
+wmic useraccount where "name='vagrant'" set PasswordExpires=FALSE

--- a/packer.json
+++ b/packer.json
@@ -51,7 +51,7 @@
      "winrm_username": "vagrant",
     "winrm_password": "vagrant",
     "winrm_timeout": "6h",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+    "shutdown_command": "stop-computer -force",
     "guest_additions_mode": "upload",
     "guest_additions_path": "c:/Windows/Temp/windows.iso",
     "vboxmanage": [
@@ -85,7 +85,8 @@
       "enable-rdp.ps1",
       "disable-hibernate.ps1",
       "disable-autologin.ps1",
-      "enable-uac.ps1"
+      "enable-uac.ps1",
+      "no-expiration.ps1"
     ]},
   {
     "type": "windows-restart",


### PR DESCRIPTION
Added an MIT license and ensured that the `vagrant` user's password never expires. 
