### PR TITLE
Virtualbox Guest Additions Fix

### DIFF
--- a/install-guest-tools.ps1
+++ b/install-guest-tools.ps1
@@ -2,11 +2,11 @@
 
 $isopath = "C:\Windows\Temp\windows.iso"
 
-# Mount the .iso, then build the path to the installer by getting the Driveletter attribute from Get-DiskImage piped into Get-Volume and adding a :\setup64.exe
+# Mount the .iso, then build the path to the installer by getting the Driveletter attribute from Get-DiskImage piped into Get-Volume and adding a :\setup.exe
 # A separate variable is used for the parameters. There are cleaner ways of doing this. I chose the /qr MSI Installer flag because I personally hate silent installers
 # Even though our build is headless. 
 
-
+Write-Output "Mounting disk image at $ispoath"
 Mount-DiskImage -ImagePath $isopath
 
 function vmware {
@@ -29,10 +29,12 @@ $VBoxCertUtil = ($certdir + 'VBoxCertUtil.exe')
 # The better way to do this would be to parse the Virtualbox version file that Packer can upload, but this was quick.
 
 if (Test-Path ($VBoxCertUtil)) {
-	Get-ChildItem *.cer | ForEach-Object {iex "$VBoxCertUtil add-trusted-publisher" $_.Name --root $_.Name}
+        Write-Output "Using newer (4.4 and above) certificate import method"
+	Get-ChildItem $certdir *.cer | ForEach-Object { & $VBoxCertUtil add-trusted-publisher $_.FullName --root $_.FullName}
 }
 
 else {
+        Write-Output "Using older (4.3 and below) certificate import method"
 	$certpath = ($certpath + 'oracle-vbox.cer')
 	certutil -addstore -f "TrustedPublisher" $certpath
 }
@@ -45,12 +47,16 @@ Start-Process $exe $parameters -Wait
 }
 
 if ($ENV:PACKER_BUILDER_TYPE -eq "vmware-iso") {
+    Write-Output "Installing VMWare Guest Tools"
     vmware
 } else {
+    Write-Output "Installing Virtualbox Guest Tools"
     virtualbox
 }
 
 #Time to clean up - dismount the image and delete the original ISO
 
+Write-Output "Dismounting disk image $isopath"
 Dismount-DiskImage -ImagePath $isopath
+Write-Output "Deleting $isopath"
 Remove-Item $isopath

--- a/install-guest-tools.ps1
+++ b/install-guest-tools.ps1
@@ -6,7 +6,7 @@ $isopath = "C:\Windows\Temp\windows.iso"
 # A separate variable is used for the parameters. There are cleaner ways of doing this. I chose the /qr MSI Installer flag because I personally hate silent installers
 # Even though our build is headless. 
 
-Write-Output "Mounting disk image at $ispoath"
+Write-Output "Mounting disk image at $isopath"
 Mount-DiskImage -ImagePath $isopath
 
 function vmware {

--- a/packer.json
+++ b/packer.json
@@ -27,7 +27,7 @@
     "tools_upload_path": "c:/Windows/Temp/windows.iso",
     "vmx_data": {
       "gui.fitguestusingnativedisplayresolution": "FALSE",
-      "memsize": "1024",
+      "memsize": "2048",
       "numvcpus": "2",
       "virtualHW.version": "10",
       "scsi0.virtualDev": "lsisas1068"
@@ -60,7 +60,7 @@
           "modifyvm",
           "{{.Name}}",
           "--memory",
-          "1024"
+          "2048"
         ],
         [
           "modifyvm",
@@ -80,7 +80,6 @@
   "provisioners": [
   {
     "type": "powershell",
-    "execute_command": "powershell -ExecutionPolicy Bypass \"& { {{.Vars}}{{.Path}}; exit $LastExitCode}\"",
     "scripts": [
       "install-guest-tools.ps1",
       "enable-rdp.ps1",


### PR DESCRIPTION
Fixed the Virtualbox installation script (it was not working) and modified the initial build environment to use 2gb of RAM, which may have absolutely zero performance impact but seemed like the right thing to do.