### PR TITLE
Shared folders won't create symlinks by default

### DIFF
--- a/vagrantfile.template
+++ b/vagrantfile.template
@@ -6,6 +6,7 @@ Vagrant.require_version ">= 1.6.2"
 Vagrant.configure("2") do |config|
     config.vm.box = "windows_10"
     config.vm.communicator = "winrm"
+    config.vm.synced_folder ".", "/vagrant", SharedFoldersEnableSymlinksCreate: false
 
     config.vm.guest = :windows
 


### PR DESCRIPTION
Disabling the SharedFoldersEnableSymlinksCreate option in the vagrantfile template for security. This may break things for some people, but I would rather treat the guest OS as unsafe by default.